### PR TITLE
Nested nav menu

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/index.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/index.py
@@ -1,4 +1,5 @@
 import dash_html_components as html
+from collections import namedtuple
 
 from .app import app
 from .utils import DashRouter, DashNavBar
@@ -14,16 +15,27 @@ urls = (
     ("character-counter", character_counter.get_layout),
     ("page2", page2.layout),
     ("page3", page3.layout),
+    ("section2/page1", page2.layout),
+    ("section2/page2", page3.layout),
 )
 
 # Ordered iterable of navbar items: tuples of `(route, display)`, where `route`
-# is a string corresponding to path of the route (will be prefixed with
+# is a string or a list of tuples corresponding to path of the route (will be prefixed with
 # 'routes_pathname_prefix') and 'display' is a valid value for the `children`
 # keyword argument for a Dash component (ie a Dash Component or a string).
+nav_item = namedtuple("nav_item", "route display")
 nav_items = (
-    ("character-counter", html.Div([fa("fas fa-keyboard"), "Character Counter"])),
-    ("page2", html.Div([fa("fas fa-chart-area"), "Page 2"])),
-    ("page3", html.Div([fa("fas fa-chart-line"), "Page 3"])),
+    nav_item(route="character-counter", display=html.Div([fa("fas fa-keyboard"), "Character Counter"])),
+    nav_item(route="page2", display=html.Div([fa("fas fa-chart-area"), "Page 2"])),
+    nav_item(route="page3", display=html.Div([fa("fas fa-chart-line"), "Page 3"])),
+    (
+        [
+            nav_item(route="section2/page1", display="S2 P1"),
+            nav_item(route="section2/page2", display="S2 P2"),
+        ],
+        "Section 2",
+    ),
+    
 )
 
 router = DashRouter(app, urls)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/utils.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/utils.py
@@ -111,7 +111,7 @@ class DashNavBar:
         app:        A Dash instance to associate the router with.
 
         nav_items:  Ordered iterable of navbar items: tuples of `(route, display)`,
-                    where `route` is a string corresponding to path of the route
+                    where `route` is either a string or list of strings corresponding to path(s) of the route
                     (will be prefixed with Dash's 'routes_pathname_prefix') and
                     'display' is a valid value for the `children` keyword argument
                     for a Dash component (ie a Dash Component or a string).
@@ -134,12 +134,38 @@ class DashNavBar:
         nav_items = []
         route_prefix = server.config["ROUTES_PATHNAME_PREFIX"]
         for i, (path, text) in enumerate(self.nav_items):
-            href = get_url(path)
-            active = (current_path == href) or (i == 0 and current_path == route_prefix)
-            nav_item = dbc.NavItem(dbc.NavLink(text, href=href, active=active))
-            nav_items.append(nav_item)
-        return html.Ul(nav_items, className="navbar-nav", **kwargs)
+            if isinstance(path, list):
+                navlinks = []
+                for nav_item in path:
+                    href = get_url(nav_item.route)
+                    active = (current_path == href) or (
+                        i == 0 and current_path == route_prefix
+                    )
+                    navlinks.append(
+                        dbc.DropdownMenuItem(
+                            dbc.NavLink(
+                                nav_item.display,
+                                href=href,
+                                active=active,
+                            ),
+                        )
+                    )
+                nav_item = dbc.DropdownMenu(
+                    navlinks,
+                    label=text,
+                    nav=True,
+                    direction="right",
+                    in_navbar=True,
+                )
 
+            else:
+                href = get_url(path)
+                active = (current_path == href) or (
+                    i == 0 and current_path == route_prefix
+                )
+                nav_item = dbc.NavItem(dbc.NavLink(text, href=href, active=active))
+            nav_items.append(nav_item)
+        return dbc.Nav(nav_items, className="navbar-nav", **kwargs)
 
 def get_dash_args_from_flask_config(config):
     """Get a dict of Dash params that were specified """


### PR DESCRIPTION
I needed to create a nested nav menu so I amended utils.py to handle a nested list of route, display tuples, create a dbc.DropdownMenu and add it to the nav_items list.
Also added an example to index.py.
Maybe not as pretty as it could be but I'm happy to change it if you think it's worthwhile.